### PR TITLE
Bump kotlin-maven-allopen from 1.7.21 to 1.7.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>recipe-bot</description>
     <properties>
         <java.version>17</java.version>
-        <kotlin.version>1.7.21</kotlin.version>
+        <kotlin.version>1.7.22</kotlin.version>
         <sonar.projectKey>Vehkiya_recipe-bot2</sonar.projectKey>
         <sonar.organization>vehkiya</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
Bumps kotlin-maven-allopen from 1.7.21 to 1.7.22.

---
updated-dependencies:
- dependency-name: org.jetbrains.kotlin:kotlin-maven-allopen dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>